### PR TITLE
Update files to list org as JuliaTesting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020 JuliaDiff
+Copyright (c) 2023 JuliaTesting
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # MetaTesting.jl
 
-[![CI](https://github.com/sethaxen/MetaTesting.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/sethaxen/MetaTesting.jl/actions/workflows/CI.yml)
-[![Coverage](https://codecov.io/gh/sethaxen/MetaTesting.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/sethaxen/MetaTesting.jl)
+[![CI](https://github.com/JuliaTesting/MetaTesting.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaTesting/MetaTesting.jl/actions/workflows/CI.yml)
+[![Coverage](https://codecov.io/gh/JuliaTesting/MetaTesting.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaTesting/MetaTesting.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
 
-[![](https://img.shields.io/badge/docs-main-blue.svg)](https://sethaxen.github.io/MetaTesting.jl/dev)
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://sethaxen.github.io/MetaTesting.jl/stable)
+[![](https://img.shields.io/badge/docs-main-blue.svg)](https://JuliaTesting.github.io/MetaTesting.jl/dev)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaTesting.github.io/MetaTesting.jl/stable)
 
 MetaTesting is a collection of utilities for testing "testers," functions that run tests.
 It is primarily intended as a test dependency.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,10 +3,10 @@ using Documenter
 
 makedocs(;
     modules=[MetaTesting],
-    repo="https://github.com/sethaxen/MetaTesting.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/JuliaTesting/MetaTesting.jl/blob/{commit}{path}#{line}",
     sitename="MetaTesting.jl",
     format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true", assets=String[]),
     pages=["Home" => "index.md"],
 )
 
-deploydocs(; repo="github.com/sethaxen/MetaTesting.jl.git", devbranch="main")
+deploydocs(; repo="github.com/JuliaTesting/MetaTesting.jl.git", devbranch="main")


### PR DESCRIPTION
This repo has now been moved to JuliaTesting (fixes #4), and this PR updates the files accordingly.